### PR TITLE
キャンペーン詳細情報取得のリファクタ

### DIFF
--- a/src/main/java/net/unit8/sigcolle/controller/CampaignController.java
+++ b/src/main/java/net/unit8/sigcolle/controller/CampaignController.java
@@ -11,7 +11,7 @@ import net.unit8.sigcolle.dao.CampaignDao;
 import net.unit8.sigcolle.dao.SignatureDao;
 import net.unit8.sigcolle.form.CampaignForm;
 import net.unit8.sigcolle.form.SignatureForm;
-import net.unit8.sigcolle.model.CampaignUser;
+import net.unit8.sigcolle.model.UserCampaign;
 import net.unit8.sigcolle.model.Signature;
 
 import static enkan.util.BeanBuilder.builder;
@@ -31,7 +31,7 @@ public class CampaignController {
 
     private HttpResponse showCampaign(Long campaignId, SignatureForm signature, String message) {
         CampaignDao campaignDao = domaProvider.getDao(CampaignDao.class);
-        CampaignUser campaign = campaignDao.selectById(campaignId);
+        UserCampaign campaign = campaignDao.selectById(campaignId);
 
         SignatureDao signatureDao = domaProvider.getDao(SignatureDao.class);
         int signatureCount = signatureDao.countByCampaignId(campaignId);

--- a/src/main/java/net/unit8/sigcolle/dao/CampaignDao.java
+++ b/src/main/java/net/unit8/sigcolle/dao/CampaignDao.java
@@ -4,7 +4,7 @@ import java.util.List;
 
 import net.unit8.sigcolle.DomaConfig;
 import net.unit8.sigcolle.model.Campaign;
-import net.unit8.sigcolle.model.CampaignUser;
+import net.unit8.sigcolle.model.UserCampaign;
 import org.seasar.doma.Dao;
 import org.seasar.doma.Insert;
 import org.seasar.doma.Select;
@@ -15,7 +15,7 @@ import org.seasar.doma.Select;
 @Dao(config = DomaConfig.class)
 public interface CampaignDao {
     @Select(ensureResult = true)
-    CampaignUser selectById(Long campaignId);
+    UserCampaign selectById(Long campaignId);
 
     @Select
     List<Campaign> selectAll();

--- a/src/main/java/net/unit8/sigcolle/model/UserCampaign.java
+++ b/src/main/java/net/unit8/sigcolle/model/UserCampaign.java
@@ -14,7 +14,7 @@ import org.seasar.doma.Id;
  */
 @Entity
 @Data
-public class CampaignUser implements Serializable {
+public class UserCampaign implements Serializable {
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long campaignId;

--- a/src/main/resources/META-INF/net/unit8/sigcolle/dao/CampaignDao/selectById.sql
+++ b/src/main/resources/META-INF/net/unit8/sigcolle/dao/CampaignDao/selectById.sql
@@ -1,4 +1,4 @@
 SELECT campaign_id, title, statement, goal, create_user_id, first_name, last_name
 FROM campaign
-JOIN user ON campaign.create_user_id = user.user_id
+INNER JOIN user ON campaign.create_user_id = user.user_id
 WHERE campaign_id=/*campaignId*/1;

--- a/src/main/resources/META-INF/net/unit8/sigcolle/dao/CampaignDao/selectById.sql
+++ b/src/main/resources/META-INF/net/unit8/sigcolle/dao/CampaignDao/selectById.sql
@@ -1,3 +1,4 @@
 SELECT campaign_id, title, statement, goal, create_user_id, first_name, last_name
-FROM campaign, user
-WHERE campaign.create_user_id = user.user_id AND campaign_id=/*campaignId*/1;
+FROM campaign
+JOIN user ON campaign.create_user_id = user.user_id
+WHERE campaign_id=/*campaignId*/1;

--- a/src/main/resources/templates/campaign.html
+++ b/src/main/resources/templates/campaign.html
@@ -27,7 +27,7 @@ xmlns:th="http://www.thymeleaf.org">
             <div class="ui information container">
                 <h1 class="ui center aligned header" th:text="${campaign.title}">Sign title</h1>
                 <div class="ui center aligned header">
-                    <a th:text="${campaign.CreatorName}">Created by</a>
+                    <a th:text="${campaign.creatorName}">Created by</a>
                 </div>
                 <div class="ui positive message" th:if="${message != null}">
                     <div class="header" th:text="${message}">Thank you</div>


### PR DESCRIPTION
* CampaignUser ===> UserCampaign
* SQLでJOINを使う
* html内のプロパティ呼び出しの1文字目を小文字化

http://doma.seasar.org/tutorial/select.html#結合した結果を取得する検索

`@OneToMany` 的なことは書いてなかったです。
実際、変にJPAの難解なアノテーションの挙動に依存するよりよっぽどわかりやすいと思います。